### PR TITLE
soong: Add `aapt_version_code` default

### DIFF
--- a/build/soong/Android.bp
+++ b/build/soong/Android.bp
@@ -135,6 +135,26 @@ camera_needs_client_info_lib_oplus {
 }
 
 soong_config_module_type {
+    name: "aapt_version_code",
+    module_type: "java_defaults",
+    config_namespace: "lineageGlobalVars",
+    value_variables: ["aapt_version_code"],
+    properties: ["aaptflags"],
+}
+
+aapt_version_code {
+    name: "aapt_version_code_defaults",
+    soong_config_variables: {
+        aapt_version_code: {
+            aaptflags: [
+                "--version-code",
+                "%s",
+            ],
+        },
+    },
+}
+
+soong_config_module_type {
     name: "gralloc_10_usage_bits",
     module_type: "cc_defaults",
     config_namespace: "customGlobalVars",

--- a/config/BoardConfigSoong.mk
+++ b/config/BoardConfigSoong.mk
@@ -25,6 +25,7 @@ $(foreach v,$(EXPORT_TO_SOONG),$(eval $(call addVar,$(v))))
 
 SOONG_CONFIG_NAMESPACES += customGlobalVars
 SOONG_CONFIG_customGlobalVars += \
+    aapt_version_code \
     additional_gralloc_10_usage_bits \
     has_legacy_camera_hal1 \
     camera_needs_client_info_lib_oplus \
@@ -93,6 +94,7 @@ TARGET_SPECIFIC_CAMERA_PARAMETER_LIBRARY ?= libcamera_parameters
 TARGET_SURFACEFLINGER_UDFPS_LIB ?= surfaceflinger_udfps_lib
 
 # Soong value variables
+SOONG_CONFIG_customGlobalVars_aapt_version_code := $(shell date -u +%Y%m%d)
 SOONG_CONFIG_customGlobalVars_additional_gralloc_10_usage_bits := $(TARGET_ADDITIONAL_GRALLOC_10_USAGE_BITS)
 SOONG_CONFIG_customGlobalVars_target_init_vendor_lib := $(TARGET_INIT_VENDOR_LIB)
 SOONG_CONFIG_customGlobalVars_has_legacy_camera_hal1 := $(TARGET_HAS_LEGACY_CAMERA_HAL1)


### PR DESCRIPTION
This appends `--version_code=$(date -u +%Y%m%d)` to aapt flags, which is useful for flushing some caches upon system updates.

Change-Id: I6575b878f09c1c3138e12abc34d39405f51245e7